### PR TITLE
bug fix:修复引入defer带来的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 bin
 cmake-build-debug
 lib
+
+*.out
+*.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(KVRaftCpp)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 # 生成debug版本，可以进行gdb调试
 set(CMAKE_BUILD_TYPE "Debug")
 
@@ -31,8 +31,6 @@ add_subdirectory(src)
 add_subdirectory(example)
 
 
-add_library(skip_list_on_raft STATIC  ${src_rpc} ${rpc_example} ${raftsource} ${src_raftCore} ${src_raftRpcPro}
-        test/include/defer.h
-        test/defer_run.cpp)
+add_library(skip_list_on_raft STATIC  ${src_rpc} ${rpc_example} ${raftsource} ${src_raftCore} ${src_raftRpcPro})
 
 target_link_libraries(skip_list_on_raft muduo_net muduo_base pthread )

--- a/src/common/include/util.h
+++ b/src/common/include/util.h
@@ -21,23 +21,23 @@
 #include <boost/archive/text_iarchive.hpp>
 
 template <class F>
-class Defer {
+class DeferClass {
 public:
-    Defer(F&& f) : m_func(std::forward<F>(f)) {}
-    Defer(const F& f) : m_func(f) {}
-    ~Defer() {
+    DeferClass(F&& f) : m_func(std::forward<F>(f)) {}
+    DeferClass(const F& f) : m_func(f) {}
+    ~DeferClass() {
         m_func();
     }
 
-    Defer(const Defer& e) = delete;
-    Defer& operator=(const Defer& e) = delete;
+    DeferClass(const DeferClass& e) = delete;
+    DeferClass& operator=(const DeferClass& e) = delete;
 
 private:
     F m_func;
 };
 
 #define _CONCAT(a, b) a##b
-#define _MAKE_DEFER_(line) Defer _CONCAT(defer, line) = [&]()
+#define _MAKE_DEFER_(line) DeferClass _CONCAT(defer_placeholder, line) = [&]()
 
 #undef DEFER
 #define DEFER _MAKE_DEFER_(__LINE__)


### PR DESCRIPTION
Defer使用了类模板参数推到，这必须要c++17及其以后，因此升级版本到了20，暂时没发现其他风险