### PR TITLE
util.h文件中format 格式化函数

### DIFF
--- a/src/common/include/util.h
+++ b/src/common/include/util.h
@@ -44,10 +44,12 @@ void myAssert(bool condition, std::string message = "Assertion failed!");
 
 template <typename... Args>
 std::string format(const char* format_str, Args... args) {
-  std::stringstream ss;
-  int _[] = {((ss << args), 0)...};
-  (void)_;
-  return ss.str();
+    int size_s = std::snprintf(nullptr, 0, format_str, args...) + 1; // "\0"
+    if (size_s <= 0) { throw std::runtime_error("Error during formatting."); }
+    auto size = static_cast<size_t>(size_s);
+    std::vector<char> buf(size);
+    std::snprintf(buf.data(), size, format_str, args...);
+    return std::string(buf.data(), buf.data() + size - 1);  // remove '\0'
 }
 
 std::chrono::_V2::system_clock::time_point now();

--- a/test/format.cpp
+++ b/test/format.cpp
@@ -1,0 +1,20 @@
+#include "../src/common/include/util.h"
+
+void myAssert(bool condition, std::string message) {
+  if (!condition) {
+    std::cerr << "Error: " << message << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+int main() {
+    // 测试格式化函数
+    myAssert(false, format("[func-AppendEntries-rf{%d}] 两节点logIndex{%d}和term{%d}相同，但是其command{%d:%d}   "
+                                 " {%d:%d}却不同！！\n",
+                                 1, 2, 3, 4, 5, 6, 7));
+    return 0;
+}
+
+// 编译命令: g++ test.cpp -o test -lboost_serialization
+
+


### PR DESCRIPTION
类似于 printf 的功能，

首先，使用 'std::snprintf' 计算格式化后的字符串长度，加上 1 以包括终止符。

然后，根据计算的大小分配一个字符缓冲区，使用 'std::snprintf' 将格式化后的字符串写入缓冲区。

最后，将缓冲区内容转换为 std::string，并去掉终止符 \0，返回结果

测试截图：
![5070734414](https://github.com/user-attachments/assets/bd343b53-9e3d-4480-8662-0d1ab052df53)
